### PR TITLE
Remove misleading information about flow ids

### DIFF
--- a/docs/Flows.md
+++ b/docs/Flows.md
@@ -2,15 +2,10 @@
 
 A flow in Flowdock is like one single team workspace, which contains a chat room and a shared inbox.
 
-In the REST API, Flow IDs are of the form `:organization/:flow`.
-
-* `organization` is the parametric name of the client organization, as seen in the subdomain of the web URL of the flow.
-* `flow` is the parametric name of the flow, as seen in the path of the web URL of the flow. Eg. `https://:organization.flowdock.com/flows/:flow`
-
-By default, the list of flows only includes those flows that the user has access to (`joined` attribute is `true`). However, if the access mode of a flow is set to `organization`, the user must explicitly join the flow to gain access. For these flows, the `joined` attribute is initially `false` and a separate "all flows" resource exists in the API for including them.
-
 ## List Flows
 Lists the flows that the authenticated user has access to. E.g. `joined` attribute of the flow is `true`.
+
+By default, the list of flows only includes those flows that the user has access to (`joined` attribute is `true`). However, if the access mode of a flow is set to `organization`, the user must explicitly join the flow to gain access. For these flows, the `joined` attribute is initially `false` and a separate "all flows" resource exists in the API for including them.
 
 ```
 GET /flows
@@ -54,7 +49,7 @@ Flowdock-User: 2
 ]
 ```
 
-* `id`: Flow resource ID
+* `id`: Flow ID
 * `url`: Flow resource URL
 * `web_url`: URL to the flow in the web UI
 * `name`: Human-readable name of the flow
@@ -68,6 +63,8 @@ Flowdock-User: 2
     - `link`: Anyone can join the flow by using the `join_url`.
     - `organization`: In addition to using the link, anyone in the organization can join the flow (it will be visible for them).
 
+
+**Note**: Flow IDs are currently in the form `:organization/:flow`, but this will change in future. IDs should be treated as opaque strings.
 
 ## List all Flows
 Lists the flows that the authenticated user has access to or can join to.

--- a/docs/Messages.md
+++ b/docs/Messages.md
@@ -172,7 +172,7 @@ Flowdock-User: 2
 * `uuid` &ndash; Optional client-generated universal identifier for message. Used to recognize messages sent by single Flowdock instance. Can be used to render sent messages instantly and later add necessary data (id) for tagging.
 * `user` &ndash; Numerical user id of user (as string)
 * `sent` &ndash; Timestamp when message was sent. Milliseconds since Jan 1st, 1970.
-* `flow` &ndash; Identifier of flow. See [Flows](Flows).
+* `flow` &ndash; Flow identifier
 * `id` &ndash; Incremental id of message. Unique only in flow scope.
 * `attachments` &ndash; List of file attachments related to this message. Example:
 

--- a/docs/REST.md
+++ b/docs/REST.md
@@ -22,14 +22,15 @@ _PATCH_ is used for most update methods instead of _PUT_ because of its ineffici
 
 ### URL Breakdown
 ```
-https://user:pass@api.flowdock.com/flows/org/flow/messages/message_id
+https://user:pass@api.flowdock.com/flows/:org/:flow/messages/:message_id
 ```
 
 * `https` -- all the Flowdock APIs are served with secure HTTP *only*
 * `user:pass` -- HTTP basic authentication credentials. You can use email/password or user specific tokens. See [Authentication](Authentication). **NOTE**: When using email/pass, remember to URI encode them. Characters outside the ASCII charset can exist in the e-mail address (the @ sign) and password.
 * `api.flowdock.com` -- the API endpoint domain
 * `flows` -- the resource which is being requested
-* `org/flow` -- identifier of the resource. See [Flows](Flows).
+* `org` -- organization identifier
+* `flow` -- parametric name of flow. See [Flows](Flows).
 * `messages` -- sub-resource, a resource which is accessed in the scope of the parent resource. Eg. all the comments of a Team Inbox item. In some cases there can be multiple sub-resources.
 * `message_id` -- identifier of the sub-resource
 


### PR DESCRIPTION
Remove big notice about flow ID format, and explain the ID format situation.

The ID format is currently quite confusing and not explained in docs. This isn't addressed in the PR.
