### PR TITLE
Add response format to posting new messages

### DIFF
--- a/docs/Messages.md
+++ b/docs/Messages.md
@@ -60,7 +60,7 @@ Link: http://api.flowdock.com/flows/acme/main/messages/12345/comments; rel="comm
   "id": 12345
   "event": "message",
   "content": "Howdy-Doo @Jackie #awesome",
-  "tags":  ["todo", "#feedback", "@all"],
+  "tags":  ["todo", "feedback", ":user:everyone", "awesome", ":user:123"],
   "user": "2",
   "uuid":"9rOhL9RS-jhr8-YvFHRfhA",
   "sent":1385546251160,


### PR DESCRIPTION
POST /messages now returns created message with ID and link to comment thread.
