### PR TITLE
External thread id in docs

### DIFF
--- a/docs/How-To-Integrate.md
+++ b/docs/How-To-Integrate.md
@@ -128,6 +128,7 @@ POST https://api.flowdock.com/messages
   },
   "title": "Opened pull request",
   "thread_id": "github:flowdock:component:pr:42",
+  "external_thread_id": "backend-123",
   "thread": {
     "title": "Fix bug in thread API",
     "body": "Body with &lt;b&gt;HTML&lt;b&gt; formatting",
@@ -145,7 +146,8 @@ The most important fields are listed below. For full reference on fields and dif
 | Name          | Description  |
 | ------------- | ------------ |
 | flow_token | The token you received after creating the integration between your application and the flow. |
-| thread_id | This is the identifier used to connect separate activities as threads. This should be a unique identifier within the scope of the integration for this particular flow. In other words, if you post two activities with the same identifier and the same flow token, those activities will be end up in the same thread. As an example, this could be a support ticket ID in a customer support system or a pull request ID in GitHub. |
+| external_thread_id | Identification for the thread that this message is a part of. For example, if you're creating an integration for an issue tracking tool, and you're sending issue change notifications to Flowdock, you would use the unique identifier of the issue. For GitHub issues, it would be the issue number, for a customer support tool, it would be the ticket ID. The ID only needs to be unique for this particular source (not the whole application). **This field is required if thread_id is not set.** |
+| thread_id | Flowdock's thread ID. Can be used to specify the thread, to which you're posting this message. **This field is required if external_thread_id is not set.** |
 
 The example application uses [a utility class](https://github.com/flowdock/flowdock-example-integration/blob/master/lib/flowdock/activity.rb) to produce JSON payloads like the example above.
 

--- a/docs/Messages.md
+++ b/docs/Messages.md
@@ -35,9 +35,8 @@ POST /flows/:organization/:flow/messages/:message/comments
 | external\_user\_name | Name that appears as the message sender. This will change the message to an anonymous message, as if it was sent from the [Push API](Chat).  |
 | uuid | An optional client-generated unique string identifier. It is the client's responsibility to ensure the uniqueness (in the scope of the flow) of the uuid. This can be, for example, used to render sent messages instantly and later add necessary data (id) for tagging. |
 | thread_id | The `id` of the [thread](threads) this message is being posted to. In order to post a message into a thread, this or `external_thread_id` is **required**. |
-| external\_thread\_id | A [source](sources)-specific string to identify the thread this message should be added to. |
+| external\_thread\_id | An ID specified by the API user, to identify the thread this message should be added to. The ID should be unique within this one [source](sources). For examples, see the integration guide's [section about posting to inbox](how-to-integrate#/post-inbox). |
 | thread | New state for the [thread](threads). |
-
 
 ```
 {
@@ -113,11 +112,12 @@ Files can also be uploaded to discussion threads using the same URL format as wi
 <div id="/thread-messages"></div>
 ### Threaded messages
 
-There are three types of messages that can belong to a thread:
+There are a few types of messages that can belong to a [thread](threads):
 
  * [Activity](message-types#/activity) - updates to a thread
  * [Discussion](message-types#/discussion) - external discussions in another service
  * [Message](message-types#/message) - comments/discussion in Flowdock
+ * [File](message-types#/file) - uploaded file stored in Flowdock
 
 To post threaded messages to a flow, you need to have an application that has been authorized by the user. This process is described in [the integration guide](how-to-integrate).
 

--- a/docs/Threads.md
+++ b/docs/Threads.md
@@ -4,6 +4,12 @@ Threads represent entities in external services. They allow users to track event
 
 Common examples of thread entities are support tickets, issues in project management software and pull requests in version control software.
 
+## Threads and messages
+
+Threads can be updated by posting [messages](messages) to them. A basic update is done by sending an [activity message](message-types#/activity) into the thread. Any message sent into a thread can contain an updated thread in the `thread` field. The activity message will serve as a kind of a change log of changes in that thread. Because of this, there is no separate way to update a thread.
+
+Likewise, any message, which is part of a thread, contains the full current state of that thread.
+
 
 ## Thread Format
 
@@ -181,11 +187,3 @@ Flowdock-User: 2
   "created_at": "2014-10-28T15:33:17.000Z"
 }
 ```
-
-
-<div id="/show"></div>
-## Threads and messages
-
-Threads can be updated by posting [messages](messages) to them. A basic update is done by sending an [activity message](message-types#/activity) into the thread. Any message sent into a thread can contain an updated thread in the `thread` field. The activity message will serve as a kind of a change log of changes in that thread. Because of this, there is no separate way to update a thread.
-
-Likewise, any message, which is part of a thread, contains the full current state of that thread.


### PR DESCRIPTION
Added mentions about external_thread_id. Includes some minor styling.
