### PR TITLE
ISO8601 created_at time

### DIFF
--- a/docs/Message-Types.md
+++ b/docs/Message-Types.md
@@ -345,7 +345,7 @@ _Bolded text denotes a required field when posting a message._
   "title": "Closed pull request",
   "body": null,
   "app": "influx",
-  "user": 0,
+  "user": "0",
   "edited": null,
   "content": null,
   "created_at": "2014-09-24T12:15:30.520Z",

--- a/docs/Message-Types.md
+++ b/docs/Message-Types.md
@@ -25,7 +25,7 @@ The message event is sent when a user sends a chat message.
 `content` is a string that contains free-form text.
 
 ### Sample
-```
+```json
 {
   "app": "chat",
   "event": "message",
@@ -36,7 +36,8 @@ The message event is sent when a user sends a chat message.
   "content": "Hello World",
   "sent": 1317715340213,
   "attachments": [],
-  "user": "2"
+  "user": "2",
+  "created_at": "2011-10-04T08:02:20.213Z"
 }
 ```
 
@@ -50,7 +51,7 @@ The status event is sent when a user changes their status.
 `content` is a string that contains free-form text.
 
 ### Sample
-```
+```json
 {
   "app": "chat",
   "sent": 1317307033981,
@@ -61,7 +62,8 @@ The status event is sent when a user changes their status.
   "event": "status",
   "content": "This is my new status",
   "user": "49",
-  "attachments": []
+  "attachments": [],
+  "created_at": "2011-10-04T08:02:20.213Z"
 }
 ```
 
@@ -78,7 +80,7 @@ contains the actual comment. The id of the parent message is stored in a [specia
 `influx:id`.
 
 ### Sample
-```
+```json
 {
   "app": "chat",
   "sent": 1317722877378,
@@ -92,7 +94,8 @@ contains the actual comment. The id of the parent message is stored in a [specia
     "text": "This is a comment"
   },
   "user": "1609",
-  "attachments": []
+  "attachments": [],
+  "created_at": "2011-10-04T10:07:57.378Z"
 }
 ```
 
@@ -141,7 +144,8 @@ string or an object.
     "description": "flowdock"
   },
   "user": "18",
-  "attachments": []
+  "attachments": [],
+  "sent": "2011-09-30T15:44:45.507Z"
 }
 ```
 
@@ -176,7 +180,8 @@ The tag-change event is sent when the tags of a message are changed. See [Tags](
     "remove": ["test"]
   },
   "user": "18",
-  "attachments": []
+  "attachments": [],
+  "created_at": "2011-09-30T15:44:45.507Z"
 }
 ```
 
@@ -209,7 +214,8 @@ The message-edit event is sent when the the content of a message is changed. Onl
     "updated_content": "foo bar"
   },
   "user": "18",
-  "attachments": []
+  "attachments": [],
+  "created_at": "2011-09-30T15:44:45.507Z"
 }
 ```
 
@@ -242,7 +248,8 @@ timestamp is not always present when e.g. user is idle.
   "sent": 1317715393030,
   "app": null,
   "attachments": [],
-  "user": '2'
+  "user": "2",
+  "created_at": "2011-10-04T08:03:13.029Z"
 }
 ```
 
@@ -294,7 +301,8 @@ The file event is sent when a file has been uploaded to the chat.
       "path": "/files/123/d19d7d7048f3012fc1e40026b0d8e16c/thumb/firefox_flowdock.png"
     }
   },
-  "tags": [":file"]
+  "tags": [":file"],
+  "created_at": "2012-03-05T13:19:54.433Z"
 }
 ```
 
@@ -340,6 +348,7 @@ _Bolded text denotes a required field when posting a message._
   "user": 0,
   "edited": null,
   "content": null,
+  "created_at": "2014-09-24T12:15:30.520Z",
   "_application": 104,
   "_project": 220,
   "thread_id": "HbjDdeOqrZm6QzlSO8rwtftzwts",
@@ -413,6 +422,7 @@ _Bolded text denotes a required field when posting a message._
   "body": "Message body with HTML formatting &lt;br&gt;&lt;br&gt;",
   "app": "influx",
   "user": "0",
+  "created_at": "2014-09-25T08:13:53.970Z",
   "edited": null,
   "content": null,
   "_application": 106,

--- a/docs/Messages.md
+++ b/docs/Messages.md
@@ -63,7 +63,8 @@ Link: http://api.flowdock.com/flows/acme/main/messages/12345/comments; rel="comm
   "uuid":"9rOhL9RS-jhr8-YvFHRfhA",
   "sent":1385546251160,
   "app":"chat",
-  "attachments":[]
+  "attachments":[],
+  "created_at": "2013-11-27T09:57:31.160Z"
 }
 ```
 
@@ -164,7 +165,8 @@ Flowdock-User: 2
       "description":"flowdock"
     },
     "attachments": [],
-    "user":"18"
+    "user":"18",
+    "created_at": "2011-09-30T15:44:45.507Z"
   },
   {
     "app": "chat",
@@ -176,7 +178,8 @@ Flowdock-User: 2
     "content": "Hello World",
     "sent": 1317715340213,
     "attachments": [],
-    "user": "2"
+    "user": "2",
+    "created_at": "2011-10-04T08:02:20.213Z"
   },
   // ... 28 more messages
 ]
@@ -212,7 +215,8 @@ Flowdock-User: 2
     "description":"flowdock"
   },
   "attachments": [],
-  "user":"18"
+  "user":"18",
+  "created_at": "2011-09-30T15:44:45.507Z"
 }
 ```
 | Name          | Description  |

--- a/docs/Private-Messages.md
+++ b/docs/Private-Messages.md
@@ -70,12 +70,12 @@ Flowdock-User: 2
     "sent": 1317397485508,
     "uuid": "odHapx1VWp7WTrdQ",
     "tags": [],
-    "to": 42,
+    "to": "42",
     "id": 3816534,
     "event": "message",
     "content": "Secret message",
     "attachments": [],
-    "user": 2,
+    "user": "2",
     "created_at": "2011-09-30T15:44:45.507Z"
   },
   {
@@ -83,12 +83,12 @@ Flowdock-User: 2
     "event": "message",
     "tags": [],
     "uuid": "4W_LQEybVaX-gJmi",
-    "to": 2,
+    "to": "2",
     "id": 45590,
     "content": "For your eyes only!",
     "sent": 1317715340213,
     "attachments": [],
-    "user": 42,
+    "user": "42",
     "created_at": "2011-10-04T08:02:20.213Z"
   },
   // ... 14 more messages
@@ -116,12 +116,12 @@ Flowdock-User: 2
   "sent": 1317397485508,
   "uuid": "odHapx1VWp7WTrdQ",
   "tags": [],
-  "to": 42,
+  "to": "42",
   "id": 3816534,
   "event": "action",
   "content": "Secret message",
   "attachments": [],
-  "user": 2,
+  "user": "2",
   "created_at": "2011-09-30T15:44:45.507Z"
 }
 ```

--- a/docs/Private-Messages.md
+++ b/docs/Private-Messages.md
@@ -75,7 +75,8 @@ Flowdock-User: 2
     "event": "message",
     "content": "Secret message",
     "attachments": [],
-    "user": 2
+    "user": 2,
+    "created_at": "2011-09-30T15:44:45.507Z"
   },
   {
     "app": "chat",
@@ -87,7 +88,8 @@ Flowdock-User: 2
     "content": "For your eyes only!",
     "sent": 1317715340213,
     "attachments": [],
-    "user": 42
+    "user": 42,
+    "created_at": "2011-10-04T08:02:20.213Z"
   },
   // ... 14 more messages
 ]
@@ -119,7 +121,8 @@ Flowdock-User: 2
   "event": "action",
   "content": "Secret message",
   "attachments": [],
-  "user": 2
+  "user": 2,
+  "created_at": "2011-09-30T15:44:45.507Z"
 }
 ```
 


### PR DESCRIPTION
Document not-yet-merged `created_at` field for messages that uses ISO8601 like most other API endpoints. The old `sent` field is still present.

There doesn't seem to be any mechanism for indicating deprecated fields or any documentation about the individual fields of a message. If there was, `sent` would be marked as deprecated although it won't disappear any time soon.