### PR TITLE
Add deprecation notice to Push API

### DIFF
--- a/docs/Chat.md
+++ b/docs/Chat.md
@@ -1,4 +1,6 @@
-# Push API: Chat
+# Push API: Chat (deprecated)
+
+**Deprecated, use [messages](Messages).**
 
 Post messages to a flow's chat from an "external user".
 

--- a/docs/Chat.md
+++ b/docs/Chat.md
@@ -1,6 +1,6 @@
 # Push API: Chat (deprecated)
 
-**Deprecated, use [messages](Messages).**
+**Deprecated, use the [Messages endpoint](Messages) instead.**
 
 Post messages to a flow's chat from an "external user".
 

--- a/docs/Push.md
+++ b/docs/Push.md
@@ -1,6 +1,6 @@
 # Push API
 
-**Push API is deprecated and will be removed in future. [Messages](Messages) endpoint provides replacement functionality. For setting up integrations, see [how to integrate](How-To-Integrate).**
+**The Push API is deprecated and will be removed. The [Messages](Messages) endpoint should be used instead. For instructions on how to build an integration, see our [integration guide](Integration-Guide).**
 
 Use the Push API to post content to
 

--- a/docs/Push.md
+++ b/docs/Push.md
@@ -1,6 +1,8 @@
 # Push API
 
-Use the Push API to post content to 
+**Push API is deprecated and will be removed in future. [Messages](Messages) endpoint provides replacement functionality. For setting up integrations, see [how to integrate](How-To-Integrate).**
+
+Use the Push API to post content to
 
 * [Team Inbox](Team Inbox)
 * [Chat](Chat)

--- a/docs/Team-Inbox.md
+++ b/docs/Team-Inbox.md
@@ -1,4 +1,7 @@
-# Push API: Team Inbox
+# Push API: Team Inbox (deprecated)
+
+**Deprecated, use [messages](Messages).**
+
 Send mail-like messages to the team inbox of a flow.
 
 ```

--- a/docs/Team-Inbox.md
+++ b/docs/Team-Inbox.md
@@ -1,6 +1,6 @@
 # Push API: Team Inbox (deprecated)
 
-**Deprecated, use [messages](Messages).**
+**Deprecated, use the [Messages endpoint](Messages) instead.**
 
 Send mail-like messages to the team inbox of a flow.
 


### PR DESCRIPTION
Warn that push API is replaced with other functionality and will be removed in future.