### PR TITLE
Syntax highlighting for all examples

### DIFF
--- a/docs/Chat.md
+++ b/docs/Chat.md
@@ -16,7 +16,8 @@ POST https://api.flowdock.com/v1/messages/chat/:flow_api_token
 | external\_user\_name | **Required** Name of the "user" sending the message. |
 | tags | Tags of the message, separated by commas. Example value: `cool,stuff` |
 | message_id | id of another message that's being commented. If supplied, instead of a regular message, adds a comment to another message. Only messages that are not comments themselves can be commented. |
-```
+
+```json
 {
   "content": "Howdy-Doo @Jackie #awesome",
   "external_user_name": "Stevie",

--- a/docs/Flows.md
+++ b/docs/Flows.md
@@ -24,7 +24,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```
+```json
 [
   {
     "id": "deadbeefdeadbeef",
@@ -107,7 +107,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```
+```json
 [
   {
     "id": "deadbeefdeadbeef",
@@ -169,7 +169,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```
+```json
 {
   "id": "deadbeefdeadbeef",
   "name": "My flow",
@@ -230,7 +230,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```
+```json
 {
   "id": "deadbeefdeadbeef",
   "name": "My flow",
@@ -304,7 +304,7 @@ HTTP/1.1 201 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 9
 ```
-```
+```json
 {
   "id": "deadbeefdeadbeef",
   "name": "My flow",
@@ -369,7 +369,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 9
 ```
-```
+```json
 {
   "id": "deadbeefdeadbeef",
   "name": "My new flow",

--- a/docs/Flows.md
+++ b/docs/Flows.md
@@ -38,7 +38,7 @@ Flowdock-User: 2
       "user_count": 10,
       "active": true,
       "url": "https://api.flowdock.com/organizations/example"
-    }
+    },
     "unread_mentions": 0,
     "open": true,
     "joined": true,
@@ -59,7 +59,7 @@ Flowdock-User: 2
       "user_count": 5,
       "active": true,
       "url": "https://api.flowdock.com/organizations/acme"
-    }
+    },
     "unread_mentions": 0,
     "open": true,
     "joined": true,
@@ -121,7 +121,7 @@ Flowdock-User: 2
       "user_count": 5,
       "active": true,
       "url": "https://api.flowdock.com/organizations/acme"
-    }
+    },
     "unread_mentions": 0,
     "open": false,
     "joined": false,
@@ -142,7 +142,7 @@ Flowdock-User: 2
       "user_count": 5,
       "active": true,
       "url": "https://api.flowdock.com/organizations/acme"
-    }
+    },
     "unread_mentions": 0,
     "open": true,
     "joined": true,

--- a/docs/General-information.md
+++ b/docs/General-information.md
@@ -29,7 +29,7 @@ Example:
 POST https://api.flowdock.com/v1/messages/chat/_YOUR_API_TOKEN_HERE_
 ```
 
-```
+```json
 {
   "external_user_name": "foobar",
   "content": ""
@@ -42,7 +42,7 @@ Response:
 HTTP/1.1 400 Bad Request
 Content-Type: application/json; charset=utf-8
 ```
-```
+```json
 {
   "message":  "Validation error",
   "errors":  {

--- a/docs/How-To-Create-Bidirectional-Integrations.md
+++ b/docs/How-To-Create-Bidirectional-Integrations.md
@@ -9,7 +9,8 @@ Here's an example activity message which includes an UpdateAction. This example 
 
 ```
 POST https://api.flowdock.com/messages
-
+```
+```json
 {
   "flow_token": "3e2252e2e164d70ebbc5c59b9db629c8",
   "event": "activity",

--- a/docs/How-To-Integrate.md
+++ b/docs/How-To-Integrate.md
@@ -76,7 +76,7 @@ POST https://api.flowdock.com/flows/:org/:flow/sources
 ```
 ```json
 {
-  name: "My project"
+  "name": "My project"
 }
 ```
 

--- a/docs/How-To-Integrate.md
+++ b/docs/How-To-Integrate.md
@@ -73,7 +73,8 @@ Example request:
 
 ```
 POST https://api.flowdock.com/flows/:org/:flow/sources
-
+```
+```json
 {
   name: "My project"
 }
@@ -85,7 +86,7 @@ POST https://api.flowdock.com/flows/:org/:flow/sources
 
 Example response data:
 
-```
+```json
 {
   "id": 36,
   "name": "My project",
@@ -120,7 +121,8 @@ Example request:
 
 ```
 POST https://api.flowdock.com/messages
-
+```
+```json
 {
   "flow_token": "3e2252e2e164d70ebbc5c59b9db629c8",
   "event": "activity",

--- a/docs/Invitations.md
+++ b/docs/Invitations.md
@@ -57,7 +57,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```
+```json
 {
   "id": 14,
   "state": "pending",
@@ -96,7 +96,7 @@ HTTP/1.1 201 Created
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```
+```json
 {
   "id": 9,
   "state": "pending",
@@ -122,7 +122,7 @@ POST /flows/:organization/:flow/invitations/import
 | list | **Required** A list of email addresses to invite. The list can be separated by commas or linefeeds, and the email addresses can be in either of the following formats: `person@example.com` or `"Joe Smith" <person@example.com>` |
 | message | An optional message that is added to the invitations. |
 
-```
+```json
 {
   "list": "someone@example.com, \"Joe Smith\" <person@example.com>",
   "message": "Please join our team's Flow."
@@ -135,7 +135,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```
+```json
 {
   "invitations": [
     {
@@ -186,6 +186,6 @@ HTTP/1.1 204 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```
+```json
 {}
 ```

--- a/docs/Message-Types.md
+++ b/docs/Message-Types.md
@@ -130,7 +130,7 @@ string or an object.
 | remove\_twitter\_search | A Twitter keyword is removed from the flow. `description` is the same as in `add_twitter_search`. |
 
 ### Sample
-```
+```json
 {
   "app": "chat",
   "sent": 1317397485508,
@@ -165,7 +165,7 @@ The tag-change event is sent when the tags of a message are changed. See [Tags](
 | remove | A list of tags that were removed from the message. |
 
 ### Sample
-```
+```json
 {
   "app": null,
   "sent": 1317397485508,
@@ -200,7 +200,7 @@ The message-edit event is sent when the the content of a message is changed. Onl
 | updated_content | The new content of the message. |
 
 ### Sample
-```
+```json
 {
   "app": null,
   "sent": 1317397425508,
@@ -235,7 +235,7 @@ These messages are not stored in Flowdock's database.
 timestamp is not always present when e.g. user is idle.
 
 ### Sample
-```
+```json
 {
   "event": "activity.user",
   "tags": [],
@@ -261,7 +261,7 @@ The file event is sent when a file has been uploaded to the chat.
 `content` is an object that contains metadata about the uploaded file. The `attachments` field will contain a single attachment with the same data. In the metadata, the `path` field contains the REST API path of the file. See [Files](files) for more.
 
 ### Sample
-```
+```json
 {
   "id": 31572,
   "app": "chat",
@@ -330,7 +330,7 @@ _Bolded text denotes a required field when posting a message._
 
 ### Sample
 
-```
+```json
 {
   "id": 13895827,
   "sent": 1411560930521,
@@ -404,7 +404,7 @@ _Bolded text denotes a required field when posting a message._
 
 ### Sample
 
-```
+```json
 {
   "id": 13904478,
   "sent": 1411632833971,

--- a/docs/Messages.md
+++ b/docs/Messages.md
@@ -41,7 +41,7 @@ Sending a message to a flow is possible using all authentication methods, includ
 | thread | New state for the [thread](threads). |
 | attachments | List of attachments for a message. Only valid for `activity` and `discussion` events. See [files](files). |
 
-```
+```json
 {
   "event": "message",
   "content": "Howdy-Doo @Jackie #awesome",
@@ -56,7 +56,7 @@ Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 Link: http://api.flowdock.com/flows/acme/main/messages/12345/comments; rel="comments"
 ```
-```
+```json
 {
   "id": 12345,
   "event": "message",
@@ -97,7 +97,7 @@ Event: `file`
 
 The format of `content` is different depending on the `Content-Type` of the request. When using `application/json`, the binary is sent as a Base64-encoded string within the JSON. Example:
 
-```
+```json
 {
   "data": "iVBORw0KGgoAAAANSUhEUgAAABQAAAAaCAYAAAC3g3x9AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJ\nbWFnZVJlYWR5ccllPAAAAElJREFUeNpiYECA/UD8n0y8nwENUGIYTkOpAhihplMNMFHbhVQ3kIVA\ncOAD/0k1kAFP+DIO3UgZTYej6XA0HY6mw9F0CAEAAQYAk/gtCSEUikYAAAAASUVORK5CYII=\n",
   "content_type": "image/png",
@@ -153,7 +153,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```javascript
+```json
 [
   {
     "app":"chat",
@@ -204,7 +204,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```javascript
+```json
 {
   "app":"chat",
   "sent":1317397485508,
@@ -235,7 +235,7 @@ Flowdock-User: 2
 | id | Incremental id of message. Unique only in the flow's scope. |
 | attachments | List of file attachments related to this message. Example: |
 
-```javascript
+```json
 [
   {
     "content_type":"text/html",
@@ -263,7 +263,7 @@ Updates a message with the specified id. Note: only certain types and certain co
 | content | The message content. Updating content is only possible for your own messages of type `message` or `comment`. |
 | tags | Full list of message [tags](Tags). Any existing tags that aren't included in this parameter are removed from the message. As in the web UI, anyone can edit the tags of any message they can see. |
 
-```javascript
+```json
 {
   "content": "Updated content",
   "tags":  ["todo", "#feedback", "@all"]
@@ -276,7 +276,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```
+```json
 {}
 ```
 

--- a/docs/Messages.md
+++ b/docs/Messages.md
@@ -153,7 +153,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```json
+```javascript
 [
   {
     "app":"chat",
@@ -235,7 +235,7 @@ Flowdock-User: 2
 | id | Incremental id of message. Unique only in the flow's scope. |
 | attachments | List of file attachments related to this message. Example: |
 
-```json
+```javascript
 [
   {
     "content_type":"text/html",

--- a/docs/Organizations.md
+++ b/docs/Organizations.md
@@ -122,7 +122,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 1
 ```
-```
+```json
 {
   "id": 42,
   "parameterized_name": "yup",
@@ -180,7 +180,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 1
 ```
-```
+```json
 {
   "id": 42,
   "parameterized_name": "yup",

--- a/docs/Private-Conversations.md
+++ b/docs/Private-Conversations.md
@@ -20,7 +20,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```
+```json
 [
   {
     "id": 42,
@@ -71,7 +71,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```
+```json
 {
   "id": 42,
   "url": "https://api.flowdock.com/private/42",
@@ -116,7 +116,7 @@ Update private conversation information.
 }
 ```
 ### Response
-```
+```json
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2

--- a/docs/Private-Conversations.md
+++ b/docs/Private-Conversations.md
@@ -116,12 +116,12 @@ Update private conversation information.
 }
 ```
 ### Response
-```json
+```
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```
+```json
 {
   "id": 42,
   "url": "https://api.flowdock.com/private/42",

--- a/docs/Private-Conversations.md
+++ b/docs/Private-Conversations.md
@@ -20,7 +20,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```json
+```javascript
 [
   {
     "id": 42,
@@ -46,7 +46,7 @@ Flowdock-User: 2
       "name": "Hubot Hubot"
     }]
   },
-  ...
+  // ...
 ]
 ```
 

--- a/docs/Private-Messages.md
+++ b/docs/Private-Messages.md
@@ -28,7 +28,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```
+```json
 {}
 ```
 

--- a/docs/SCIM.md
+++ b/docs/SCIM.md
@@ -28,7 +28,7 @@ GET https://api.flowdock.com/scim/:uid
 ```
 
 #### Response
-```
+```json
 {
   "message": "Authorization ok"
 }
@@ -87,7 +87,7 @@ Content-Type: application/json
 
 #### Response
 
-```
+```json
 {
   "Resources": [
     {
@@ -164,7 +164,7 @@ Content-Type: application/json
 
 #### Response
 
-```
+```json
 {
   "id": 1,
   "externalId":"johndoe@example.com",
@@ -220,7 +220,8 @@ PUT https://api.flowdock.com/scim/123456/Users/1
 Authorization: Bearer 1b54iFrTbKIgP0Fl657cHA
 Accept: application/json
 Content-Type: application/json
-
+```
+```json
 {
   "name": {
     "givenName": "New",
@@ -302,7 +303,8 @@ POST https://api.flowdock.com/scim/123456/Users
 Authorization: Bearer 1b54iFrTbKIgP0Fl657cHA
 Accept: application/json
 Content-Type: application/json
-
+```
+```json
 {
   "userName": "johndoe"
   "name": {
@@ -323,7 +325,7 @@ Content-Type: application/json
 
 A successfull request will result in a `201 Created` response.
 
-```
+```json
 {
   "id": 1,
   "externalId":"johndoe",

--- a/docs/SCIM.md
+++ b/docs/SCIM.md
@@ -306,7 +306,7 @@ Content-Type: application/json
 ```
 ```json
 {
-  "userName": "johndoe"
+  "userName": "johndoe",
   "name": {
     "givenName": "John",
     "familyName": "Doe"

--- a/docs/Streaming.md
+++ b/docs/Streaming.md
@@ -52,15 +52,17 @@ The [EventSource API](http://www.w3.org/TR/eventsource/#the-eventsource-interfac
 is implemented in most browsers. Even older browsers can use this interface via a
 [polyfill](https://github.com/Yaffle/EventSource).
 
+```javascript
     var stream = new EventSource('https://stream.flowdock.com/flows?filter=<flow-id>&access_token=<oauth-token>')
     stream.onmessage = function(event) {
       var message = JSON.parse(event.data);
       // handle message
     }
-
+```
 
 ## Ruby Example (JSON stream)
 
+```ruby
     require 'eventmachine'
     require 'em-http'
     require 'json'
@@ -83,6 +85,7 @@ is implemented in most browsers. Even older browsers can use this interface via 
         end
       end
     end
+```
 
 ## Ruby Example (Event-Stream)
 

--- a/docs/Tags.md
+++ b/docs/Tags.md
@@ -5,7 +5,7 @@ In Flowdock, the user interacts directly with two types of tags: *hashtags* and 
 
 The following message sent to Flowdock...
 
-```
+```json
 {
   "event": "message",
   "content": "@Marty, there's a severe #bug in the flux-capacitor, see http://example.com",
@@ -15,7 +15,7 @@ The following message sent to Flowdock...
 
 ...would be dispatched to other listening clients in this form:
 
-```
+```json
 {
   "event": "message",
   "content": "@Marty, there's a severe #bug in the flux-capacitor.",

--- a/docs/Team-Inbox.md
+++ b/docs/Team-Inbox.md
@@ -23,7 +23,7 @@ POST https://api.flowdock.com/v1/messages/team_inbox/:flow_api_token
 | tags | List of [tags](Tags) to be added to the message. Can either be an array (JSON only) or a string with tags delimited with commas. User tags should start with '@'. Hashtags can optionally be prefixed with "#". Tags are case insensitive. These are equivalent: `["@Mike", "#cool", "awesome"]` and `"#awesome,cool,@mike"` |
 | link | Link associated with the message. This will be used to link the message subject in the team inbox. Example value: `http://www.flowdock.com/` |
 
-```
+```json
 {
   "source": "News digest service",
   "from_address": "news@example.com",
@@ -38,7 +38,7 @@ POST https://api.flowdock.com/v1/messages/team_inbox/:flow_api_token
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 ```
-```
+```json
 {}
 ```
 

--- a/docs/Users.md
+++ b/docs/Users.md
@@ -120,7 +120,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```
+```json
 {
   "id": 9,
   "email": "john@example.com",
@@ -157,7 +157,7 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```
+```json
 {}
 ```
 
@@ -217,6 +217,6 @@ HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
 Flowdock-User: 2
 ```
-```
+```json
 {}
 ```


### PR DESCRIPTION
Some examples have syntax highlighting classes already (e.g. the Tags page), this PR adds them to all examples across the docs (JSON, Ruby, Javascript). 

Note: you can only see the effect when serving the docs through `propaganda` which has the appropriate stylesheets.